### PR TITLE
Added 'test-only' adb override for device runner

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -190,11 +190,12 @@ public final class SpoonDeviceRunner {
 
     // Now install the main application and the instrumentation application.
     try {
-      String extraArgument = "";
+      List<String> extraArgument = new ArrayList<String>(2);
+      extraArgument.add("-t"); // Required to allow the APK to tested once installed.
       if (grantAll && deviceDetails.getApiLevel() >= DeviceDetails.MARSHMALLOW_API_LEVEL) {
-        extraArgument = "-g";
+        extraArgument.add("-g");
       }
-      device.installPackage(apk.getAbsolutePath(), true, extraArgument);
+      device.installPackage(apk.getAbsolutePath(), true, extraArgument.toArray(new String[extraArgument.size()]));
     } catch (InstallException e) {
       logInfo("InstallException while install app apk on device [%s]", serial);
       e.printStackTrace(System.out);


### PR DESCRIPTION
Added 'test-only' override to the app install to avoid the `com.android.ddmlib.InstallException: INSTALL_FAILED_TEST_ONLY: installPackageLI` error message.